### PR TITLE
#5 API 도메인 변경

### DIFF
--- a/en/api-guide-v1.0.md
+++ b/en/api-guide-v1.0.md
@@ -5,7 +5,7 @@ Certificate Manager provides APIs to upload or download certificates. Clients mu
 ### Basic Information
 #### EndPoint
 ```text
-https://alpha-api-certmanager.cloud.toast.com
+https://alpha-api-certificate-manager.cloud.toast.com
 ```
 
 #### Available API Types 
@@ -50,7 +50,7 @@ Regarding supported certificate file formats (.pem), read '[Troubleshooting Guid
 #### Request
 
 ```
-POST https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
+POST https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
 ```
 
 [Request Header]
@@ -93,7 +93,7 @@ Certificate files registered at Certificate Manager can be downloaded.
 #### Request
 
 ```
-GET https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
+GET https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
 ```
 
 #### Response
@@ -122,13 +122,13 @@ Download Certificate File API can be requested by using the `curl` command.
 
 ```sh
 #Write to File
-curl 'https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files' > cert.pem
+curl 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files' > cert.pem
 
 #Specify File Name
-curl -o cert.pem 'https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
+curl -o cert.pem 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
 
 #Maintain Uploaded File Name
-curl -OJ 'https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
+curl -OJ 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
 ```
 * See the link below on how to use curl command
   * curl command guide : [https://curl.haxx.se/docs/manpage.html](https://curl.haxx.se/docs/manpage.html)

--- a/ja/api-guide-v1.0.md
+++ b/ja/api-guide-v1.0.md
@@ -5,7 +5,7 @@ Certificate Managerでは証明書のアップロード、ダウンロードを�
 ### 基本情報
 #### EndPoint
 ```text
-https://alpha-api-certmanager.cloud.toast.com
+https://alpha-api-certificate-manager.cloud.toast.com
 ```
 
 #### 提供するAPI種類
@@ -50,7 +50,7 @@ Certificate Managerに登録した証明書にファイルをアップロード�
 #### リクエスト
 
 ```
-POST https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
+POST https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
 ```
 
 [Request Header]
@@ -93,7 +93,7 @@ Certificate Managerに登録した証明書ファイルをダウンロードす�
 #### リクエスト
 
 ```
-GET https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
+GET https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
 ```
 
 #### レスポンス
@@ -125,10 +125,10 @@ Content-Type:application/octet-stream
 curl 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files' > cert.pem
 
 #ファイル名指定
-curl -o cert.pem 'https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
+curl -o cert.pem 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
 
 #アップロードしたファイル名を維持
-curl -OJ 'https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
+curl -OJ 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
 ```
 * その他curlコマンドの使用方法は下記のガイドを参照してください。
   * curl command guide : [https://curl.haxx.se/docs/manpage.html](https://curl.haxx.se/docs/manpage.html)

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -5,7 +5,7 @@ Certificate Manager에서는 인증서 업로드, 다운로드를 위한 API를 
 ### 기본 정보
 #### EndPoint
 ```text
-https://alpha-api-certmanager.cloud.toast.com
+https://alpha-api-certificate-manager.cloud.toast.com
 ```
 
 #### 제공하는 API 종류
@@ -50,7 +50,7 @@ Certificate Manager에 등록한 인증서에 파일을 업로드할 때 사용�
 #### 요청
 
 ```
-POST https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
+POST https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
 ```
 
 [Request Header]
@@ -93,7 +93,7 @@ Certificate Manager에 등록한 인증서 파일을 다운로드할 때 사용�
 #### 요청
 
 ```
-GET https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
+GET https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
 ```
 
 #### 응답
@@ -122,13 +122,13 @@ Content-Type:application/octet-stream
 
 ```sh
 #파일에 쓰기
-curl 'https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files' > cert.pem
+curl 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files' > cert.pem
 
 #파일명 지정
-curl -o cert.pem 'https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
+curl -o cert.pem 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
 
 #업로드한 파일명 유지
-curl -OJ 'https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
+curl -OJ 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
 ```
 * 기타 curl 명령어 사용법은 아래 가이드를 참고해 주시기 바랍니다.
   * curl command guide : [https://curl.haxx.se/docs/manpage.html](https://curl.haxx.se/docs/manpage.html)

--- a/zh/api-guide-v1.0.md
+++ b/zh/api-guide-v1.0.md
@@ -5,7 +5,7 @@ Certificate Manager에서는 인증서 업로드, 다운로드를 위한 API를 
 ### 기본 정보
 #### EndPoint
 ```text
-https://alpha-api-certmanager.cloud.toast.com
+https://alpha-api-certificate-manager.cloud.toast.com
 ```
 
 #### 제공하는 API 종류
@@ -50,7 +50,7 @@ Certificate Manager에 등록한 인증서에 파일을 업로드할 때 사용�
 #### 요청
 
 ```
-POST https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
+POST https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
 ```
 
 [Request Header]
@@ -93,7 +93,7 @@ Certificate Manager에 등록한 인증서 파일을 다운로드할 때 사용�
 #### 요청
 
 ```
-GET https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
+GET https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files
 ```
 
 #### 응답
@@ -122,13 +122,13 @@ Content-Type:application/octet-stream
 
 ```sh
 #파일에 쓰기
-curl 'https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files' > cert.pem
+curl 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files' > cert.pem
 
 #파일명 지정
-curl -o cert.pem 'https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
+curl -o cert.pem 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
 
 #업로드한 파일명 유지
-curl -OJ 'https://alpha-api-certmanager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
+curl -OJ 'https://alpha-api-certificate-manager.cloud.toast.com/certmanager/v1.0/appkeys/{appKey}/certificates/{certificateName}/files'
 ```
 * 기타 curl 명령어 사용법은 아래 가이드를 참고해 주시기 바랍니다.
   * curl command guide : [https://curl.haxx.se/docs/manpage.html](https://curl.haxx.se/docs/manpage.html)


### PR DESCRIPTION
alpha-api-certmanager.cloud.toast.com -> alpha-api-certificate-manager.cloud.toast.com